### PR TITLE
remove shell set

### DIFF
--- a/plugin/fcitx-osx.vim
+++ b/plugin/fcitx-osx.vim
@@ -10,7 +10,6 @@ if exists('g:fcitx_remote')
   finish
 endif
 
-set shell=bash
 set ttimeoutlen=50
 
 if (has("win32") || has("win95") || has("win64") || has("win16"))


### PR DESCRIPTION
插件中的set shell 会覆盖用户自己设置的shell 配置. 我删掉插件里面的配置后插件也可以正常工作
