### PR TITLE
进入vim的时候，将输入设成en。

### DIFF
--- a/plugin/fcitx-osx.vim
+++ b/plugin/fcitx-osx.vim
@@ -61,6 +61,7 @@ function BindAu()
   augroup Fcitx
    au InsertLeave * call Fcitx2en()
    au InsertEnter * call Fcitx2zh()
+   au VimEnter * call Fcitx2en()
   augroup END
 endfunction
 


### PR DESCRIPTION
打开中文文件时进入vim会带着中文的输入法状态。这时让它直接切到en去。