### PR TITLE
添加一个选项

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Use vundle
 Plugin 'CodeFalling/fcitx-vim-osx'
 ```
 
+# options
+if you do not need change to zh when you enter insert mode 
+```
+let g:fcitx_vim_osx_only_en = 1
+```
+
 # For OS X
 
 You have to install https://github.com/CodeFalling/fcitx-remote-for-osx

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# modified
+forked from https://github.com/xcodebuild/fcitx-vim-osx
+remove the feature that when enter insert mode change to zh. just keep en
+
 # fcitx-vim-osx
 Modified fcitx.vim for osx with https://github.com/CodeFalling/fcitx-remote-for-osx
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Plugin 'CodeFalling/fcitx-vim-osx'
 
 # Options
 if you do not need change to zh when you enter insert mode 
-```
+```vim
 let g:fcitx_vim_osx_only_en = 1
 ```
 

--- a/plugin/fcitx-osx.vim
+++ b/plugin/fcitx-osx.vim
@@ -10,8 +10,6 @@ if exists('g:fcitx_remote')
   finish
 endif
 
-set ttimeoutlen=50
-
 if (has("win32") || has("win95") || has("win64") || has("win16"))
   " Windows 下不要载入
   finish
@@ -45,39 +43,20 @@ function Fcitx2zh()
   endtry
 endfunction
 " ---------------------------------------------------------------------
-" Autocmds:
-function Fcitx2zhOnce()
-  call Fcitx2zh()
-  call UnBindAu()
-endfunction
-
-function BindAu2zhOnce()
-  augroup Fcitx
-   au InsertEnter * call Fcitx2zhOnce()
-  augroup END
-endfunction
-
 function BindAu()
   augroup Fcitx
    au InsertLeave * call Fcitx2en()
-   au InsertEnter * call Fcitx2zh()
    au VimEnter * call Fcitx2en()
   augroup END
 endfunction
 
 function UnBindAu()
   au! Fcitx InsertLeave *
-  au! Fcitx InsertEnter *
 endfunction
 
 call BindAu()
 
 "Called once right before you start selecting multiple cursors
-function! Multiple_cursors_before()
-  call UnBindAu()
-  call BindAu2zhOnce()
-endfunction
-
 function! Multiple_cursors_after()
   call Fcitx2en()
   call BindAu()
@@ -87,6 +66,5 @@ endfunction
 "  Restoration And Modelines:
 let &cpo=s:keepcpo
 unlet s:keepcpo
-"vim:fdm=expr:fde=getline(v\:lnum-1)=~'\\v"\\s*-{20,}'?'>1'\:1
 
 let g:fcitx_remote = 1

--- a/plugin/fcitx-osx.vim
+++ b/plugin/fcitx-osx.vim
@@ -10,6 +10,8 @@ if exists('g:fcitx_remote')
   finish
 endif
 
+let s:only_en = get(g:, 'fcitx_vim_osx_only_en', 0)
+
 set ttimeoutlen=50
 
 if (has("win32") || has("win95") || has("win64") || has("win16"))
@@ -35,6 +37,9 @@ function Fcitx2en()
   endif
 endfunction
 function Fcitx2zh()
+  if s:only_en == 1
+    return
+  endif
   try
     if b:inputtoggle == 1
       let t = system("fcitx-remote -o")

--- a/plugin/fcitx-osx.vim
+++ b/plugin/fcitx-osx.vim
@@ -11,6 +11,8 @@ if exists('g:fcitx_remote')
 endif
 
 let s:only_en = get(g:, 'fcitx_vim_osx_only_en', 0)
+let s:fcitx_use_remote = get(g:, 'fcitx_use_remote', v:false)
+let s:fcitx_remote_url = get(g:, 'fcitx_remote_url', 0)
 
 set ttimeoutlen=50
 
@@ -18,18 +20,17 @@ if (has("win32") || has("win95") || has("win64") || has("win16"))
   " Windows 下不要载入
   finish
 endif
-if exists('$SSH_TTY')
-  finish
-endif
-if !executable("fcitx-remote")
-  finish
-endif
+
 let s:keepcpo = &cpo
 let g:loaded_fcitx = 1
 set cpo&vim
 " ---------------------------------------------------------------------
 " Functions:
 function Fcitx2en()
+  if s:fcitx_use_remote == v:true && len(s:fcitx_remote_url) != 0
+    let r = system('wget -q ' . s:fcitx_remote_url . ' -O /dev/null')
+    return
+  endif
   let inputstatus = system("fcitx-remote")
   if inputstatus == 2
     let b:inputtoggle = 1


### PR DESCRIPTION
选项 
```vim
let g:fcitx_vim_osx_only_en = 1
```
允许只执行中文->英文切换。
