### PR TITLE
fix: 部分兼容用户设置的`ttimeoutlen`参数值(#12)

### DIFF
--- a/plugin/fcitx-osx.vim
+++ b/plugin/fcitx-osx.vim
@@ -10,7 +10,9 @@ if exists('g:fcitx_remote')
   finish
 endif
 
-set ttimeoutlen=50
+if &ttimeoutlen <= 0 || &ttimeoutlen > 50
+    set ttimeoutlen=50
+endif
 
 if (has("win32") || has("win95") || has("win64") || has("win16"))
   " Windows 下不要载入


### PR DESCRIPTION
若用户设置的该值更小，就使用用户配置的值。

该值的作用：
终端下请设置 Vim 'ttimeoutlen' 选项为较小值（如100），否则退出插入模式时会有较严重的延迟。
同样会造成延迟的还有 screen 的 maptimeout 选项以及 tmux 的 escape-time 选项。